### PR TITLE
Use https links to questions

### DIFF
--- a/canonical.html
+++ b/canonical.html
@@ -156,7 +156,7 @@
                         });
 
                         questionLink = document.createElement('a');
-                        questionLink.href = question.link.replace(/^http/, 'https');
+                        questionLink.href = question.link.replace(/^(http:)?\/\//, 'https://');
                         questionLink.target = '_blank';
                         questionLink.innerHTML = question.title;
 

--- a/canonical.html
+++ b/canonical.html
@@ -156,7 +156,7 @@
                         });
 
                         questionLink = document.createElement('a');
-                        questionLink.href = question.link;
+                        questionLink.href = question.link.replace(/^http/, 'https');
                         questionLink.target = '_blank';
                         questionLink.innerHTML = question.title;
 


### PR DESCRIPTION
A live test/preview can be viewed [here](https://rawgit.com/RAnders00/Room-11.github.io/patch-1/canonical.html).

Note that the offered solution will not affect any occurrences of `http` somewhere else in the URL.
