### PR TITLE
Remove eval.in link

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,8 +109,7 @@
         </li>
         <li id="do_3">
             <p>Use <a href="https://gist.github.com/">gist.github.com</a> to post code when asking for help
-                (other services such as <a href="http://3v4l.org/">3v4l.org</a> and 
-                <a href="http://eval.in">eval.in</a> are also available)
+                (other services such as <a href="https://3v4l.org/">3v4l.org</a> are also available)
             </p>
             <span class="description">This is to prevent large wall of texts that may become obstrusive to conversations.</span>
         </li>


### PR DESCRIPTION
The service that was here in 2017,[1] has not existed for a number of years now. The domain is now part of a generic content farm. [2]

[1] http://web.archive.org/web/20170710044424/http://eval.in/
[2] http://web.archive.org/web/20220505212821/http://eval.in/